### PR TITLE
Remove Trig trait, replace it Float trait and log ops

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ use std::{
 
 
 pub use primitives::DimError;
-pub use scalars::{Scalar, Trig};
+pub use scalars::{Scalar, Float};
 pub use helpers::{broadcast_shape, const_max};
 pub use primitives::{Broadcast, Reduce, Slice, Reshape, Transpose};
 pub use maps::{Bimap, Map};
@@ -340,9 +340,16 @@ mod tests {
     }
 
     #[test]
-    fn trig() {
-        let a = Ndarr::from([0.1, 0.2]);
-        assert_eq!(a.sin(), Ndarr::from([0.1_f64.sin(), 0.2_f64.sin()]))
+    fn float_ops() {
+        let a = Ndarr::from([0.1]);
+        assert_eq!(a.sin(), Ndarr::from([0.1_f64.sin()]));
+        assert_eq!(a.cos(), Ndarr::from([0.1_f64.cos()]));
+        assert_eq!(a.tan(), Ndarr::from([0.1_f64.tan()]));
+        assert_eq!(a.sinh(), Ndarr::from([0.1_f64.sinh()]));
+        assert_eq!(a.cosh(), Ndarr::from([0.1_f64.cosh()]));
+        assert_eq!(a.ln(), Ndarr::from([0.1_f64.ln()]));
+        assert_eq!(a.log2(), Ndarr::from([0.1_f64.log2()]));
+        assert_eq!(a.log(3.0), Ndarr::from([0.1_f64.log(3.0)]));
     }
     #[test]
     fn reshape(){

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1,4 +1,4 @@
-use crate::{scalars::{Scalar, Trig}, primitives::{Broadcast, DimError, Reduce, BroadcastData}, helpers::{const_max}};
+use crate::{scalars::{Scalar, Float}, primitives::{Broadcast, DimError, Reduce, BroadcastData}, helpers::{const_max}};
 
 use super::*;
 use std::ops::*;
@@ -616,7 +616,7 @@ where
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////  Trig Functions /////////////////////////////////////////////
 impl <T, const R: usize> Ndarr<T,R> 
-where T: Clone + Copy + Debug + Default + Trig
+where T: Clone + Debug + Default + Float
 {
     pub fn sin(&self)->Self{
         let out = self.clone().map(|x| x.f_sin());
@@ -647,6 +647,29 @@ where T: Clone + Copy + Debug + Default + Trig
         let out = self.clone().map(|x| x.f_tanh());
         out
     }
+
+    pub fn log(&self, base: T)->Self{
+        let out = self.clone().map(|x| x.f_log(base));
+        out
+    }
+    
+    pub fn ln(&self)->Self{
+        let out = self.clone().map(|x| x.f_ln());
+        out
+    }
+
+    pub fn log2(&self)->Self{
+        let out = self.clone().map(|x| x.f_log2());
+        out
+    }
+
+    pub fn log10(&self)->Self{
+        let out = self.clone().map(|x| x.f_log10());
+        out
+    }
+    
+   
+
 }
 
 // TODO: find a better way

--- a/src/scalars.rs
+++ b/src/scalars.rs
@@ -1,3 +1,5 @@
+use std::{process::Output, ops::Neg};
+
 use crate::helpers::multiply_list;
 
 use super::*;
@@ -51,54 +53,84 @@ where
     }
 }
 
-pub trait Trig {
-    fn f_sin(&self) -> Self;
-    fn f_cos(&self) -> Self;
-    fn f_tan(&self) -> Self;
-    fn f_sinh(&self) -> Self;
-    fn f_cosh(&self) -> Self;
-    fn f_tanh(&self) -> Self;
+pub trait Float: Copy + PartialOrd + Neg<Output = Self> {
+    fn f_sin(self) -> Self;
+    fn f_cos(self) -> Self;
+    fn f_tan(self) -> Self;
+    fn f_sinh(self) -> Self;
+    fn f_cosh(self) -> Self;
+    fn f_tanh(self) -> Self;
+    // logs
+    fn f_log(self, base: Self)->Self;
+    fn f_ln(self)->Self;
+    fn f_log2(self)->Self;
+    fn f_log10(self)->Self;
 }
 
-impl Trig for f32 {
-    fn f_sin(&self) -> Self {
+
+impl Float for f32 {
+    fn f_sin(self) -> Self {
         self.sin()
     }
-    fn f_cos(&self) -> Self {
+    fn f_cos(self) -> Self {
         self.cos()
     }
-    fn f_tan(&self) -> Self {
+    fn f_tan(self) -> Self {
         self.tan()
     }
-    fn f_sinh(&self) -> Self {
+    fn f_sinh(self) -> Self {
         self.sinh()
     }
-    fn f_cosh(&self) -> Self {
+    fn f_cosh(self) -> Self {
         self.cosh()
     }
-    fn f_tanh(&self) -> Self {
+    fn f_tanh(self) -> Self {
         self.tanh()
+    }
+    fn f_log(self, base: Self)->Self{
+        self.log(base)
+    }
+    fn f_ln(self)->Self{
+        self.ln()
+    }
+    fn f_log2(self)->Self{
+        self.log2()
+    }
+    fn f_log10(self)->Self{
+        self.log10()
     }
 }
 
-impl Trig for f64 {
-    fn f_sin(&self) -> Self {
+impl Float for f64 {
+    fn f_sin(self) -> Self {
         self.sin()
     }
-    fn f_cos(&self) -> Self {
+    fn f_cos(self) -> Self {
         self.cos()
     }
-    fn f_tan(&self) -> Self {
+    fn f_tan(self) -> Self {
         self.tan()
     }
-    fn f_sinh(&self) -> Self {
+    fn f_sinh(self) -> Self {
         self.sinh()
     }
-    fn f_cosh(&self) -> Self {
+    fn f_cosh(self) -> Self {
         self.cosh()
     }
-    fn f_tanh(&self) -> Self {
+    fn f_tanh(self) -> Self {
         self.tanh()
+    }
+    fn f_log(self, base: Self)->Self{
+        self.log(base)
+    }
+    fn f_ln(self)->Self{
+        self.ln()
+    }
+    fn f_log2(self)->Self{
+        self.log2()
+    }
+    fn f_log10(self)->Self{
+        self.log10()
     }
 }
 


### PR DESCRIPTION
Trig functions can only be done for Float Types, as well as Log functions. It makes more sense to have a single `Float` trait instead of two `Trig` and `Log` traits.