### PR TITLE
Complex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,5 @@ license = "MIT"
 [dependencies]
 num-traits = "0.2.15"
 
-[feature]
+[features]
 complex = []

--- a/src/complex/cast.rs
+++ b/src/complex/cast.rs
@@ -1,4 +1,5 @@
 use super::*;
+use num_traits::{Num, identities::zero};
 //impl<T,P> From<C<P>> for C<T> 
 //where T: Copy + PartialEq + From<P>,
 //P: Copy + PartialEq
@@ -7,6 +8,14 @@ use super::*;
         //C(value.0.into(), value.1.into())     
    //} 
 //}
+
+impl<T> From<T> for C<T> 
+where T: Num + Copy
+{
+   fn from(value: T) -> Self {
+        C(value, zero())
+   } 
+}
 
 macro_rules!  cast_complex{
     ($T:tt, $P:tt) => {

--- a/src/complex/floats.rs
+++ b/src/complex/floats.rs
@@ -9,12 +9,17 @@ impl<T: Float> C<T> {
     pub fn arg(&self) -> T {
         // theta
         //(self.1 / self.0).atan()
-        self.0.atan2(self.1)
+        self.1.atan2(self.0)
     }
     pub fn exp(&self) -> Self {
         C(self.0.exp() * self.1.cos(), self.0.exp() * self.1.sin())
     }
     pub fn ln(&self) -> Self {
+        // Main branch complex logarithm with ln(-1)=iπ (as in numpy)
+        // Note this function is not continous since the complex logarithm is only continous
+        // if no closed curve around 0 exists. To make the complex logarithm continous,
+        // typically, a curve from 0 to infinity is removed from the input domain.
+        // Commonly this curve is the negative real axis. Then ln(-1) is no longer defined.
         C(self.abs().ln(), self.arg())
     }
     pub fn sin(&self) -> Self {

--- a/src/complex/mod.rs
+++ b/src/complex/mod.rs
@@ -46,26 +46,26 @@ where
 #[cfg(test)]
 mod tests {
 
-    use std::f32::consts::PI;
+    use std::f32::consts::{PI, FRAC_PI_2, LN_2};
 
     use super::*;
 
     #[test]
-    fn test_add() {
+    fn add() {
         assert_eq!(1 + 1.i(), C(1, 1));
         assert_eq!(1.i() + 1, C(1, 1));
         assert_eq!(C(0., 2.) + C(2., 3.), C(2., 5.));
     }
 
     #[test]
-    fn test_sub() {
+    fn sub() {
         assert_eq!(1 - 1.i(), C(1, -1));
         assert_eq!(1.i() - 1, C(-1, 1));
         assert_eq!(C(0., 2.) - C(2., 3.), C(-2., -1.));
     }
 
     #[test]
-    fn test_mul() {
+    fn mul() {
         let c1 = 2 + 3.i();
         let c2 = 4 + 5.i();
         let expected = -7 + 22.i();
@@ -73,7 +73,7 @@ mod tests {
     }
 
     #[test]
-    fn test_division() {
+    fn division() {
         let c1 = C(2., 3.);
         let c2 = C(4., 5.);
         let expected = C(23. / 41., 2./ 41.);
@@ -81,9 +81,36 @@ mod tests {
     }
 
     #[test]
-    fn test_conj(){
+    fn conj() {
         let a: C<i32> = 2 + 3.i();
         assert!((a * a.conj()).re() == a.r_square())
     }
 
+    #[test]
+    fn from_num() {
+        let a: u8 = 42;
+        let a_complex = C::from(a);
+        assert_eq!(a_complex, C(42,0));
+
+        let a: f32 = 42.0;
+        let a_complex = C::from(a);
+        assert_eq!(a_complex, C(42.0,0.0));
+
+        let a: i32 = -42;
+        let a_complex = C::from(a);
+        assert_eq!(a_complex, C(-42,0));
+    }
+
+    #[test]
+    fn ln() {
+        let a = C(0.0, 1.0);
+        assert_eq!(a.ln(), C(0.0, FRAC_PI_2));
+
+        let a = C(2.0, 0.0);
+        assert_eq!(a.ln(), C(LN_2, 0.0));
+
+        let a = C(-1.0, 0.0);
+        assert_eq!(a.ln(), C(0.0, PI));
+    }
 }
+ 

--- a/src/complex/primitives.rs
+++ b/src/complex/primitives.rs
@@ -1,29 +1,12 @@
 use super::*;
+use num_traits::{Num, identities::zero};
 
 pub trait Imag<T: Copy + PartialEq> {
     fn i(&self) -> C<T>;
 }
-macro_rules! prim_to_im {
-    ($T:tt) => {
-        impl Imag<$T> for $T {
-            fn i(&self) -> C<$T> {
-                C(0_u8 as $T, *self)
-            }
-        }
-    };
-}
 
-prim_to_im!(u8);
-prim_to_im!(u16);
-prim_to_im!(u32);
-prim_to_im!(u64);
-prim_to_im!(u128);
-prim_to_im!(i8);
-prim_to_im!(i16);
-prim_to_im!(i32);
-prim_to_im!(i64);
-prim_to_im!(i128);
-prim_to_im!(f32);
-prim_to_im!(f64);
-prim_to_im!(usize);
-prim_to_im!(isize);
+impl<T: Num + Copy> Imag<T> for T {
+    fn i(&self) -> C<T> {
+        C(zero(), *self)
+    }
+}


### PR DESCRIPTION
This pull request involves the following:

- Renaming of tests to better fit the naming in `lib.rs`
- Simplification on the implementation of the `Imag` trait for primitive types via the `num_traits` `Num` trait instead of using macros
- Bugfix in the `arg` function which used $\text{atan2}\left(\frac{y}{x}\right)$ instead of $\text{atan2}\left(\frac{x}{y}\right)$ where the complex number $z=x+iy$.
- Implementation of the From trait for complex numbers for primitive types via the `Num` trait.
- Typo in the `Cargo.toml` which caused that `complex` was not a feature