### PR TITLE
Activation functions and approximate equal for Ndarr

### DIFF
--- a/src/complex/floats.rs
+++ b/src/complex/floats.rs
@@ -1,5 +1,5 @@
 use super::*;
-use num_traits::{Float};
+use num_traits::Float;
 
 impl<T: Float> C<T> {
     pub fn abs(&self) -> T {

--- a/src/complex/mod.rs
+++ b/src/complex/mod.rs
@@ -1,4 +1,4 @@
-use num_traits::{Num};
+use num_traits::Num;
 use std::{
     fmt::{Debug, Display},
     ops::{Add, AddAssign, Div, Mul, MulAssign, Neg},

--- a/src/complex/ops.rs
+++ b/src/complex/ops.rs
@@ -1,5 +1,3 @@
-
-
 use super::*;
 use std::ops::*;
 

--- a/src/complex_tensor.rs
+++ b/src/complex_tensor.rs
@@ -1,6 +1,4 @@
-use std::{
-    ops::{Add, Div, Mul, MulAssign, Neg},
-};
+use std::ops::{Add, Div, Mul, MulAssign, Neg};
 
 use super::*;
 use crate::complex::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,8 @@ pub use helpers::{broadcast_shape, const_max};
 #[cfg(feature = "complex")]
 pub use complex::*;
 
+use num_traits::Float;
+
 ///Main struct of N Dimensional generic array. The shape is denoted by the `shape` array where the length is the Rank of the Ndarray the actual values are stored in a flattened state in a rank 1 array.
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -301,6 +303,30 @@ where
     }
     fn get_rank(&self) -> usize {
         R
+    }
+}
+
+impl<T: Float + Clone + Debug + Default, const R: usize> Ndarr<T, R> {
+    fn approx_epsilon<const R2: usize>(&self, other: &Ndarr<T, R2>, epsilon: T) -> bool
+    where
+        [usize; const_max(R2, R)]: Sized,
+        [usize; const_max(R, R2)]: Sized,
+    {
+        let diff = self - other;
+        for val in diff.data {
+            if val > epsilon {
+                return false;
+            }
+        }
+        true
+    }
+
+    fn approx<const R2: usize>(&self, other: &Ndarr<T, R2>) -> bool
+    where
+        [usize; const_max(R2, R)]: Sized,
+        [usize; const_max(R, R2)]: Sized,
+    {
+        self.approx_epsilon(other, T::from(1e-10).unwrap())
     }
 }
 

--- a/src/ops/extras.rs
+++ b/src/ops/extras.rs
@@ -25,8 +25,9 @@ impl<T, const R: usize> Ndarr<T, R>
 where
     T: Clone + Debug + Default,
 {
-    pub fn sum(&self) -> T 
-        where T :Add<Output = T>,
+    pub fn sum(&self) -> T
+    where
+        T: Add<Output = T>,
     {
         let data = &self.data;
         let mut sum = data[0].clone();
@@ -37,28 +38,26 @@ where
     }
 
     pub fn max(&self) -> Option<&T>
-        where T : Ord,
+    where
+        T: Ord,
     {
         self.data.iter().max()
     }
 }
 
-
 #[cfg(test)]
-mod test_extras{
+mod test_extras {
     use super::Ndarr;
 
     #[test]
-    fn max(){
-        let arr = Ndarr::from([-2,0,4,8]);
+    fn max() {
+        let arr = Ndarr::from([-2, 0, 4, 8]);
         assert_eq!(arr.max().unwrap(), &8)
     }
 
     #[test]
-    fn sum(){
-        let arr = Ndarr::from([-2,0,4,8]);
+    fn sum() {
+        let arr = Ndarr::from([-2, 0, 4, 8]);
         assert_eq!(arr.sum(), 10)
     }
 }
-
-

--- a/src/ops/floats.rs
+++ b/src/ops/floats.rs
@@ -59,11 +59,19 @@ where
     }
 
     ///Max Float, floating types do not implement `Ord`, but this gives a way to get the maximum value in an `Ndarr` if all comparisons are allowed.
-    pub fn maxf(&self)->T{
-        self.data.clone().into_iter().reduce(T::max).expect("Cannot perform fmax deu to imposable comparison")
+    pub fn maxf(&self) -> T {
+        self.data
+            .clone()
+            .into_iter()
+            .reduce(T::max)
+            .expect("Cannot perform fmax deu to imposable comparison")
     }
     ///Min Float, floating types do not implement `Ord`, but this gives a way to get the minimum value in an `Ndarr` if all comparisons are allowed.
-    pub fn minf(&self)->T{
-        self.data.clone().into_iter().reduce(T::min).expect("Cannot perform minf due to imposable comparison.")
+    pub fn minf(&self) -> T {
+        self.data
+            .clone()
+            .into_iter()
+            .reduce(T::min)
+            .expect("Cannot perform minf due to imposable comparison.")
     }
 }

--- a/src/scalars.rs
+++ b/src/scalars.rs
@@ -1,5 +1,3 @@
-
-
 use crate::helpers::multiply_list;
 
 use super::*;

--- a/src/utils/activation.rs
+++ b/src/utils/activation.rs
@@ -2,23 +2,24 @@ use num_traits::Float;
 
 use super::*;
 
-impl <T: Float + Default + Clone + Debug, const R: usize> Ndarr<T,R> {
+impl<T: Float + Default + Clone + Debug, const R: usize> Ndarr<T, R> {
     //Sigmoid function
-    pub fn sigmoid(&self)->Self{
+    pub fn sigmoid(&self) -> Self {
         self.map(|x| T::one() / (T::one() + (-*x).exp()))
     }
-    //Relu 
-    pub fn relu(&self)->Self{
+
+    //Relu
+    pub fn relu(&self) -> Self {
         self.map(|x| x.max(T::zero()))
     }
 
-    //LeakyRelu  
-    pub fn leaky_relu(&self, a: T)->Self{
+    //LeakyRelu
+    pub fn leaky_relu(&self, a: T) -> Self {
         self.map(|x| x.max(a * *x))
     }
 
-    //Softmax 
-    pub fn softmax(&self)->Self{
+    //Softmax
+    pub fn softmax(&self) -> Self {
         let max = self.maxf();
         let exp = self.map(|x| *x - max).exp();
         let sum = exp.sum();
@@ -27,30 +28,33 @@ impl <T: Float + Default + Clone + Debug, const R: usize> Ndarr<T,R> {
 }
 
 #[cfg(test)]
-mod test_act{
+mod test_act {
     use super::*;
     #[test]
-    fn sigmoid(){
+    fn sigmoid() {
         let x = Ndarr::from([0., 1., 2., 3., 4., 5.]);
-        println!("{}", x.sigmoid())//[0.5        0.73105858 0.88079708 0.95257413 0.98201379 0.99330715]
+        println!("{}", x.sigmoid()) //[0.5        0.73105858 0.88079708 0.95257413 0.98201379 0.99330715]
     }
 
     #[test]
-    fn relu(){
+    fn relu() {
         let x = Ndarr::from([-2., -1., 0., 1., 2.]);
         assert_eq!(x.relu(), Ndarr::from([0., 0., 0., 1., 2.]))
     }
 
     #[test]
-    fn leaky_relu(){
+    fn leaky_relu() {
         let x = Ndarr::from([-2., -1., 0., 1., 2.]);
         assert_eq!(x.leaky_relu(0.1), Ndarr::from([-0.2, -0.1, 0., 1., 2.]))
     }
 
     #[test]
 
-    fn softmax(){
+    fn softmax() {
         let x = Ndarr::from([1., 2., 3.]);
-        assert_eq!(x.softmax(), Ndarr::from([0.09003057317038046, 0.24472847105479764, 0.6652409557748218]));
+        assert_eq!(
+            x.softmax(),
+            Ndarr::from([0.09003057317038046, 0.24472847105479764, 0.6652409557748218])
+        );
     }
 }

--- a/src/utils/activation.rs
+++ b/src/utils/activation.rs
@@ -167,6 +167,70 @@ mod test_act {
     use super::*;
 
     #[test]
+    fn threshold() {
+        let x = Ndarr::from([-1., 0., 1., 2., 3.]);
+        assert_eq!(
+            x.threshold(&1.0, &42.0),
+            Ndarr::from([42., 42., 42., 2., 3.])
+        );
+    }
+
+    #[test]
+    fn hard_tanh() {
+        let x = Ndarr::from([-2., -1., 0., 1., 2., 3.]);
+        assert_eq!(
+            x.hard_tanh(&-1.5, &2.0),
+            Ndarr::from([-1.5, -1., 0., 1., 2., 2.])
+        );
+    }
+
+    #[test]
+    fn elu() {
+        let x = Ndarr::from([-2., -1., 0., 1., 2., 3.]);
+        assert!(x.elu(&1.5).approx(&Ndarr::from([
+            -1.29699707514508096215900075,
+            -0.9481808382428365176067,
+            0.,
+            1.,
+            2.,
+            3.
+        ])));
+    }
+
+    #[test]
+    fn hard_shrink() {}
+
+    #[test]
+    fn hard_sigmoid() {}
+
+    #[test]
+    fn hard_swish() {}
+
+    #[test]
+    fn log_sigmoid() {}
+
+    #[test]
+    fn relu_6() {}
+
+    #[test]
+    fn selu() {}
+
+    #[test]
+    fn celu() {}
+
+    #[test]
+    fn silu() {}
+
+    #[test]
+    fn softplus() {}
+
+    #[test]
+    fn mish() {}
+
+    #[test]
+    fn softshrink() {}
+
+    #[test]
     fn sigmoid() {
         let x = Ndarr::from([0., 1., 2., 3., 4., 5.]);
         println!("{}", x.sigmoid()) //[0.5        0.73105858 0.88079708 0.95257413 0.98201379 0.99330715]

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,8 +1,8 @@
-use super::*;
 use super::Ndarr;
+use super::*;
 
-mod fill_arr;
 mod activation;
+mod fill_arr;
 
 #[cfg(feature = "rapl_image")]
 pub mod rapl_img;

--- a/src/utils/rapl_img.rs
+++ b/src/utils/rapl_img.rs
@@ -2,7 +2,7 @@ use super::Ndarr;
 
 use image::*;
 
-use std::{path::Path};
+use std::path::Path;
 
 pub use image::ImageFormat;
 


### PR DESCRIPTION
Added most of the activation functions provided by [PyTorch](https://pytorch.org/docs/stable/nn.html#non-linear-activations-weighted-sum-nonlinearity)
Not implemented are:
- [MultiheadAttention](https://pytorch.org/docs/stable/generated/torch.nn.MultiheadAttention.html#torch.nn.MultiheadAttention)
- [PRelu](https://pytorch.org/docs/stable/generated/torch.nn.PReLU.html#torch.nn.PReLU)
- [RRelu](https://pytorch.org/docs/stable/generated/torch.nn.RReLU.html#torch.nn.RReLU)
- [GELU](https://pytorch.org/docs/stable/generated/torch.nn.GELU.html#torch.nn.GELU) 
- [GLU](https://pytorch.org/docs/stable/generated/torch.nn.GLU.html#torch.nn.GLU)

Also added an approximate equal functions for the Ndarr type.