### PR TITLE
Updated `NdarrRand` to allow passing of optional seed value

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ license = "MIT"
 image = {version = "0.24.6", optional = true}
 num-traits = "0.2.15"
 rand = "0.8.5"
+rand_chacha = "0.3.1"
 rand_distr = "0.4.3"
 typenum = "1.16.0"
 

--- a/examples/conway_gol.rs
+++ b/examples/conway_gol.rs
@@ -8,19 +8,29 @@ use std::{
 const N: usize = 17;
 const STEPS: usize = 100;
 
-fn update(mat: &mut Ndarr<i8,U2>){
-    let rolls = Ndarr::from([1,0,-1]);
-    let out = rolls.map(|r| mat.roll(*r, 0)).outer_product(&rolls, |a, r| a.roll(r, 1)).sum();
-    mat.bimap_in_place(&out, |prev, new| if new == 3|| (prev == 1 &&  (new == 4)){1}else{0})
+fn update(mat: &mut Ndarr<i8, U2>) {
+    let rolls = Ndarr::from([1, 0, -1]);
+    let out = rolls
+        .map(|r| mat.roll(*r, 0))
+        .outer_product(&rolls, |a, r| a.roll(r, 1))
+        .sum();
+    mat.bimap_in_place(&out, |prev, new| {
+        if new == 3 || (prev == 1 && (new == 4)) {
+            1
+        } else {
+            0
+        }
+    })
 }
 
-fn main(){
-    let mut x = NdarrRand::choose(&[0,1], [N,N]);//initialize game matrix with random 0 or 1
+fn main() {
+    //initialize game matrix with random 0 or 1
+    let mut x = NdarrRand::choose(&[0, 1], [N, N], None);
     let mut stdout = stdout();
     stdout.flush().unwrap();
     stdout.write_all(b"\x1B[2J\x1B[1;1H").unwrap();
 
-    for i in 0..STEPS{
+    for i in 0..STEPS {
         update(&mut x); //call update function
         let vis = x.map(|x| {
             if *x == 0 {
@@ -29,13 +39,15 @@ fn main(){
                 "█".to_string()
             }
         }); //make it pretty
-        println!("{}",vis);
+        println!("{}", vis);
         println!(
-            "\n Conway's Game of Life using rapl: [Step {} out of {}] \n"
-        , i + 1, STEPS);
+            "\n Conway's Game of Life using rapl: [Step {} out of {}] \n",
+            i + 1,
+            STEPS
+        );
         sleep(Duration::from_millis(50));
         stdout.write_all(b"\x1B[1;1H").unwrap();
         stdout.flush().unwrap();
     }
-   stdout.write_all(b"\x1B[2J\x1B[1;1H").unwrap();
+    stdout.write_all(b"\x1B[2J\x1B[1;1H").unwrap();
 }

--- a/examples/ising_model.rs
+++ b/examples/ising_model.rs
@@ -11,17 +11,15 @@ const T: f32 = 0.05; // Temperature
 const STEPS: usize = 700; //Steps of simulation
 const M: usize = 20; //Number of updates per metropolis circle
 
-
-fn metropolis(spin_arr: &mut Ndarr<f32, U2>){  
-    let energy:Ndarr<f32, U2> = 2. * spin_arr.clone() * (spin_arr.roll(1, 0)+
-                                                    spin_arr.roll(-1, 0) +
-                                                    spin_arr.roll(1, 1) +
-                                                    spin_arr.roll(-1, 1));
-    let temp_exp = (- &energy / T).exp(); 
+fn metropolis(spin_arr: &mut Ndarr<f32, U2>) {
+    let energy: Ndarr<f32, U2> = 2.
+        * spin_arr.clone()
+        * (spin_arr.roll(1, 0) + spin_arr.roll(-1, 0) + spin_arr.roll(1, 1) + spin_arr.roll(-1, 1));
+    let temp_exp = (-&energy / T).exp();
     let indexes: Vec<usize> = (0..N).collect();
-    let i_s = NdarrRand::choose(&indexes, [M]); //random i indexes
-    let j_s = NdarrRand::choose(&indexes, [M]); //random j indexes
-    let p_swich: f32 = NdarrRand::uniform(0.0,1.0, [1])[0]; // selection probability of random spin switch
+    let i_s = NdarrRand::choose(&indexes, [M], None); //random i indexes
+    let j_s = NdarrRand::choose(&indexes, [M], None); //random j indexes
+    let p_swich: f32 = NdarrRand::uniform(0.0, 1.0, [1], None)[0]; // selection probability of random spin switch
     for (i, j) in i_s.data.iter().zip(j_s.data.iter()) {
         if energy[[*i, *j]] < 0.0 || p_swich < temp_exp[[*i, *j]] {
             spin_arr[[*i, *j]] *= &-1.0;
@@ -31,7 +29,7 @@ fn metropolis(spin_arr: &mut Ndarr<f32, U2>){
 
 fn main() {
     let mut stdout = stdout();
-    let mut spin_arr = NdarrRand::choose(&[-1.0, 1.0], [N, N]);
+    let mut spin_arr = NdarrRand::choose(&[-1.0, 1.0], [N, N], None);
     stdout.flush().unwrap();
     stdout.write_all(b"\x1B[2J\x1B[1;1H").unwrap();
     for i in 0..STEPS {

--- a/src/utils/random.rs
+++ b/src/utils/random.rs
@@ -4,13 +4,14 @@ use rand::distributions::uniform::SampleUniform;
 use rand::distributions::Uniform;
 use rand::prelude::*;
 use rand::seq::IteratorRandom;
+use rand_chacha::ChaCha8Rng;
 use rand_distr::{Distribution, Normal, StandardNormal};
 
 /// Struct to encapsulate all the random functionality.
 pub struct NdarrRand {}
 
 impl NdarrRand {
-    /// Generates a random N-dimensional array with values x~U(low, high)
+    /// Generates a random N-dimensional array with values x ~ U(low, high)
     pub fn uniform<
         T: SampleUniform + Debug + Clone + Copy + Default,
         R: Unsigned,
@@ -19,51 +20,136 @@ impl NdarrRand {
         low: T,
         high: T,
         shape: D,
+        seed: Option<u64>,
     ) -> Ndarr<T, R> {
         let d: Dim<R> = shape.into();
         let n = d.get_number_elements();
-        let mut rng = rand::thread_rng();
-        let random_vector: Vec<T> = (0..n)
-            .map(|_| rng.sample(Uniform::new(low, high)))
-            .collect();
+        let random_vector: Vec<T> = match seed {
+            Some(s) => {
+                let mut rng = ChaCha8Rng::seed_from_u64(s);
+                (0..n)
+                    .map(|_| rng.sample(Uniform::new(low, high)))
+                    .collect()
+            }
+            None => {
+                let mut rng = rand::thread_rng();
+                (0..n)
+                    .map(|_| rng.sample(Uniform::new(low, high)))
+                    .collect()
+            }
+        };
         Ndarr::new(&random_vector, d).unwrap()
     }
-    pub fn choose<T: Debug + Clone + Default, R: Unsigned, D: Into<Dim<R>>>(
-        elements: &[T],
-        shape: D,
-    ) -> Ndarr<T, R> {
-        let d: Dim<R> = shape.into();
-        let n = d.get_number_elements();
-        let mut rng = rand::thread_rng();
-        let elements = elements.iter();
-        let random_vector: Vec<T> = (0..n)
-            .map(|_| elements.clone().choose(&mut rng).unwrap().clone())
-            .collect();
-        Ndarr::new(&random_vector, d).unwrap()
-    }
-    /// Generates a random N-dimensional array with values x~N(μ, σ^2)
+
+    /// Generates a random N-dimensional array with values x ~ N(μ, σ^2)
     pub fn normal<T: Debug + Clone + Copy + Default + Float, R: Unsigned, D: Into<Dim<R>>>(
         mu: T,
         sigma: T,
         shape: D,
+        seed: Option<u64>,
     ) -> Ndarr<T, R>
     where
         StandardNormal: Distribution<T>,
     {
         let d: Dim<R> = shape.into();
         let n = d.get_number_elements();
-        let mut rng = rand::thread_rng();
         let normal = Normal::new(mu, sigma).unwrap();
-        let random_vector: Vec<T> = (0..n).map(|_| normal.sample(&mut rng)).collect();
+        let random_vector: Vec<T> = match seed {
+            Some(s) => {
+                let mut rng = ChaCha8Rng::seed_from_u64(s);
+                (0..n).map(|_| normal.sample(&mut rng)).collect()
+            }
+            None => {
+                let mut rng = rand::thread_rng();
+                (0..n).map(|_| normal.sample(&mut rng)).collect()
+            }
+        };
+        Ndarr::new(&random_vector, d).unwrap()
+    }
+
+    /// Generate a random N-dimensional array by taking draws from a given array
+    /// `elements` with replacement.
+    pub fn choose<T: Debug + Clone + Default, R: Unsigned, D: Into<Dim<R>>>(
+        elements: &[T],
+        shape: D,
+        seed: Option<u64>,
+    ) -> Ndarr<T, R> {
+        let d: Dim<R> = shape.into();
+        let n = d.get_number_elements();
+        let elements = elements.iter();
+        let random_vector: Vec<T> = match seed {
+            Some(s) => {
+                let mut rng = ChaCha8Rng::seed_from_u64(s);
+                (0..n)
+                    .map(|_| elements.clone().choose(&mut rng).unwrap().clone())
+                    .collect()
+            }
+            None => {
+                let mut rng = rand::thread_rng();
+                (0..n)
+                    .map(|_| elements.clone().choose(&mut rng).unwrap().clone())
+                    .collect()
+            }
+        };
         Ndarr::new(&random_vector, d).unwrap()
     }
 }
 
 #[cfg(test)]
 mod rng_arr {
-    //use super::*;
+    use super::*;
     #[test]
-    fn test_rand() {
-        //let a = NdarrRand::uniform(0.0, 1.0, [2,2]);
+    fn test_normal_f64() {
+        let arr = NdarrRand::normal(0f64, 1f64, [2, 2], Some(1234));
+        let tgt = Ndarr::from([
+            -0.3047064644834838,
+            1.8246424684819205,
+            0.4733072797360177,
+            -0.717657616639252,
+        ])
+        .reshape([2, 2])
+        .unwrap();
+        assert!(arr == tgt);
+    }
+
+    #[test]
+    fn test_normal_f32() {
+        let arr = NdarrRand::normal(0f32, 1f32, [2, 2], Some(1234));
+        let tgt = Ndarr::from([-0.30470645, 1.8246424, 0.47330728, -0.7176576])
+            .reshape([2, 2])
+            .unwrap();
+        assert!(arr == tgt);
+    }
+
+    #[test]
+    fn test_uniform_f64() {
+        let arr = NdarrRand::uniform(0f64, 1f64, [2, 2], Some(1234));
+        let tgt = Ndarr::from([
+            0.38637312192058193,
+            0.9963256225585044,
+            0.5968809870290679,
+            0.3163402777023183,
+        ])
+        .reshape([2, 2])
+        .unwrap();
+        assert!(arr == tgt);
+    }
+
+    #[test]
+    fn test_uniform_f32() {
+        let arr = NdarrRand::uniform(0f32, 1f32, [2, 2], Some(1234));
+        let tgt = Ndarr::from([0.7023206, 0.38637304, 0.055616498, 0.9963256])
+            .reshape([2, 2])
+            .unwrap();
+        assert!(arr == tgt);
+    }
+
+    #[test]
+    fn test_choose() {
+        let arr = NdarrRand::choose(&[1, 2, 3, 4, 5], [3, 3], Some(1234));
+        let tgt = Ndarr::from([4, 1, 5, 2, 5, 4, 3, 3, 4])
+            .reshape([3, 3])
+            .unwrap();
+        assert!(arr == tgt);
     }
 }

--- a/src/utils/rapl_img.rs
+++ b/src/utils/rapl_img.rs
@@ -8,28 +8,30 @@ use typenum::{U2, U3};
 
 pub use image::ImageFormat;
 
-///Open an image as RGB represented as  `Ndarr<u8,3>` where the axis dimensions are (width, height, 3), were the depth represent each color channel.
-pub fn open_rgbu8(path: &dyn AsRef<Path>) -> Result<Ndarr<u8, U3>, ImageError> {
+/// Open an image as RGB represented as  `Ndarr<u8,3>` where the axis dimensions
+/// are (width, height, 3), were the depth represent each color channel.
+pub fn open_rgbu8<P: AsRef<Path>>(path: P) -> Result<Ndarr<u8, U3>, ImageError> {
     let img = image::open(path)?.to_rgb8();
     let (w, h) = (img.width(), img.height());
     let _n = w as usize * h as usize * 3;
 
-    let data_arr = img.iter().map(|x| *x).collect();
+    let data_arr = img.iter().copied().collect();
     Ok(Ndarr {
         data: data_arr,
         dim: Dim::new(&[w as usize, h as usize, 3]).unwrap(),
     })
 }
 
-/// Open an image as RGB represented as  `Ndarr<f32,3>` where the axis dimensions are (width, height, 3), were the depth represent each color channel.
+/// Open an image as RGB represented as  `Ndarr<f32,3>` where the axis dimensions
+/// are (width, height, 3), were the depth represent each color channel.
 /// Each subpixel has a value from 0 to 1.
-pub fn open_rgbf32(path: &dyn AsRef<Path>) -> Result<Ndarr<f32, U3>, ImageError> {
+pub fn open_rgbf32<P: AsRef<Path>>(path: P) -> Result<Ndarr<f32, U3>, ImageError> {
     //open image transform to rgb8
     let img = image::open(path)?.to_rgb32f();
     let (w, h) = (img.width(), img.height());
     let _n = w as usize * h as usize * 3;
 
-    let data_arr = img.iter().map(|x| *x).collect();
+    let data_arr = img.iter().copied().collect();
     Ok(Ndarr {
         data: data_arr,
         dim: Dim::new(&[w as usize, h as usize, 3]).unwrap(),
@@ -37,26 +39,27 @@ pub fn open_rgbf32(path: &dyn AsRef<Path>) -> Result<Ndarr<f32, U3>, ImageError>
 }
 
 ///Open an image as Luma (black and white) represented as  `Ndarr<u8,2>` where the axis dimensions are (width, height).
-pub fn open_lumau8(path: &dyn AsRef<Path>) -> Result<Ndarr<u8, U2>, ImageError> {
+pub fn open_lumau8<P: AsRef<Path>>(path: P) -> Result<Ndarr<u8, U2>, ImageError> {
     let img = image::open(path)?.to_luma8();
     let (w, h) = (img.width(), img.height());
     let _n = w as usize * h as usize;
 
-    let data_arr = img.iter().map(|x| *x).collect();
+    let data_arr = img.iter().copied().collect();
     Ok(Ndarr {
         data: data_arr,
         dim: Dim::new(&[w as usize, h as usize]).unwrap(),
     })
 }
 
-///Open an image as Luma (black and white) represented as  `Ndarr<f32,2>` where the axis dimensions are (width, height).
+/// Open an image as Luma (black and white) represented as  `Ndarr<f32,2>`
+/// where the axis dimensions are (width, height).
 /// Each pixel is detonted by a f32 from 0.0 to 1.0.
-pub fn open_lumaf32(path: &dyn AsRef<Path>) -> Result<Ndarr<f32, U2>, ImageError> {
+pub fn open_lumaf32<P: AsRef<Path>>(path: P) -> Result<Ndarr<f32, U2>, ImageError> {
     let img = image::open(path)?.to_luma32f();
     let (w, h) = (img.width(), img.height());
     let _n = w as usize * h as usize;
 
-    let data_arr = img.iter().map(|x| *x).collect();
+    let data_arr = img.iter().copied().collect();
     Ok(Ndarr {
         data: data_arr,
         dim: Dim::new(&[w as usize, h as usize]).unwrap(),
@@ -64,8 +67,9 @@ pub fn open_lumaf32(path: &dyn AsRef<Path>) -> Result<Ndarr<f32, U2>, ImageError
 }
 
 impl Ndarr<u8, U3> {
-    /// Saves a Ndarr<u8,3> with shape (with, heighth, 3) as RGB Image. Takes path and format, where format is enum: `ImageFormat`.
-    pub fn save_as_rgb(&self, path: &dyn AsRef<Path>, fmt: ImageFormat) {
+    /// Saves a Ndarr<u8,3> with shape (with, heighth, 3) as RGB Image. Takes
+    /// path and format, where format is enum: `ImageFormat`.
+    pub fn save_as_rgb<P: AsRef<Path>>(&self, path: P, fmt: ImageFormat) {
         assert!(
             self.dim.shape[2] == 3,
             "Cannot convert Ndarr of shape {:?} to RGB image",
@@ -82,8 +86,9 @@ impl Ndarr<u8, U3> {
 }
 
 impl Ndarr<f32, U3> {
-    /// Saves a Ndarr<f32,3> with shape (with, heighth, 3) as RGB Image. Takes path and format, where format is enum: `ImageFormat`.
-    pub fn save_as_rgb(&self, path: &dyn AsRef<Path>, fmt: ImageFormat) {
+    /// Saves a Ndarr<f32,3> with shape (with, heighth, 3) as RGB Image. Takes
+    /// path and format, where format is enum: `ImageFormat`.
+    pub fn save_as_rgb<P: AsRef<Path>>(&self, path: P, fmt: ImageFormat) {
         assert!(
             self.dim.shape[2] == 3,
             "Cannot convert Ndarr of shape {:?} to RGB image",
@@ -100,8 +105,9 @@ impl Ndarr<f32, U3> {
 }
 
 impl Ndarr<u8, U2> {
-    /// Saves a Ndarr<u8,2> with shape (with, heighth) as Luma (Black and white) Image. Takes path and format, where format is enum: `ImageFormat`.
-    pub fn save_as_luma(&self, path: &dyn AsRef<Path>, fmt: ImageFormat) {
+    /// Saves a Ndarr<u8,2> with shape (with, heighth) as Luma (Black and white)
+    /// Image. Takes path and format, where format is enum: `ImageFormat`.
+    pub fn save_as_luma<P: AsRef<Path>>(&self, path: P, fmt: ImageFormat) {
         let w = self.dim.shape[0];
         let h = self.dim.shape[1];
         let img: ImageBuffer<Luma<u8>, Vec<u8>> =
@@ -113,8 +119,10 @@ impl Ndarr<u8, U2> {
 }
 
 impl Ndarr<f32, U2> {
-    /// Normalize a Ndarr<f32,2> to values form 0.0 to 1.0 and saves it as Luma (Black and white) Image. Takes path and format, where format is enum: `ImageFormat`.
-    pub fn save_as_luma(&self, path: &dyn AsRef<Path>, fmt: ImageFormat) {
+    /// Normalize a Ndarr<f32,2> to values form 0.0 to 1.0 and saves it as
+    /// Luma (Black and white) Image. Takes path and format, where format
+    /// is enum: `ImageFormat`.
+    pub fn save_as_luma<P: AsRef<Path>>(&self, path: P, fmt: ImageFormat) {
         let max = self
             .data
             .iter()
@@ -140,23 +148,22 @@ impl Ndarr<f32, U2> {
 
 #[cfg(test)]
 mod image_test {
-
     use super::*;
     use crate::de_slice;
     #[test]
     fn open_rgb8() {
-        let img = open_rgbu8(&"graphics\\test_img.jpg").unwrap();
+        let img = open_rgbu8("graphics/test_img.jpg").unwrap();
         let mut slices = img.slice_at(2);
         slices[2].map_in_place(|x| x.wrapping_add(200));
         let des = de_slice(&slices, 2);
-        des.save_as_rgb(&"graphics\\out_blue.png", ImageFormat::Png);
+        des.save_as_rgb("graphics/out_blue.png", ImageFormat::Png);
     }
     #[test]
     fn open_f32() {
-        let img = open_lumaf32(&"graphics\\test_img.jpg").unwrap();
-        img.save_as_luma(&"graphics\\out_test_bw.jpg", ImageFormat::Png);
+        let img = open_lumaf32("graphics/test_img.jpg").unwrap();
+        img.save_as_luma("graphics/out_test_bw.jpg", ImageFormat::Png);
         //square image
         let square = &img * &img;
-        square.save_as_luma(&"graphics\\out_test_bw_square.jpg", ImageFormat::Png);
+        square.save_as_luma("graphics/out_test_bw_square.jpg", ImageFormat::Png);
     }
 }


### PR DESCRIPTION
Additional WIP work on #30
 
* For testing + reproducibility purposes, setting a seed value via basic `u64` value added. Not cryptographically secure, but suitable for the envisioned applications at this point in time.
* Also added some basic tests, and propagated the new function signatures to the examples.
* Also changed the function signatures of the `rapl_img.rs` functions to be OS-agnostic to get tests to pass, which have been included here by accident, should have been in a separate PR.